### PR TITLE
Update JsonSerializable.php

### DIFF
--- a/src/JsonSerializable.php
+++ b/src/JsonSerializable.php
@@ -7,8 +7,8 @@
  */
 
 /**
- * JsonSerializable interface. This file should only be loaded on PHP < 5.4
- * It allows us to implement it in classes without requiring PHP 5.4
+ * JsonSerializable interface. This file provides backwards compatibility to PHP 5.3 and ensures
+ * the interface is present in systems where JSON related code was removed.
  *
  * @link   http://www.php.net/manual/en/jsonserializable.jsonserialize.php
  * @since  1.0


### PR DESCRIPTION
JsonSerializable is missing in PHP5.5 on Debian Linux servers so we need to keep loading this in the future - see https://github.com/joomla/joomla-cms/pull/3018
