### PR TITLE
Use current HHVM rather than an EOL version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,6 @@ matrix:
       group: edge # Until the next major stable image update
   allow_failures:
     - php: hhvm
-    - php: 7.0
-    - php: 7.0
 
 before_script:
   - composer update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,19 @@
 # Force Faster Travis-CI Container Infrastructure
 sudo: false
 language: php
-
-php:
-  - 5.3
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
+dist: trusty
 
 matrix:
   fast_finish: true
   include:
+    - php: 5.3
+      dist: precise
+    - php: 5.4
+    - php: 5.5
+    - php: 5.6
+    - php: 7.0
+    - php: 7.1
     - php: hhvm
-      sudo: true
-      dist: trusty
-      group: edge # Until the next major stable image update
   allow_failures:
     - php: hhvm
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+# Force Faster Travis-CI Container Infrastructure
+sudo: false
 language: php
 
 php:
@@ -6,11 +8,18 @@ php:
   - 5.5
   - 5.6
   - 7.0
-  - hhvm
+  - 7.1
 
 matrix:
+  fast_finish: true
+  include:
+    - php: hhvm
+      sudo: true
+      dist: trusty
+      group: edge # Until the next major stable image update
   allow_failures:
     - php: hhvm
+    - php: 7.0
     - php: 7.0
 
 before_script:


### PR DESCRIPTION
Pull Request for Issue testing against EOL hhvm 3.6.6

### Summary of Changes
This provides the current HHVM version (3.15.3 as of this PR) and will track with each release (i.e. will be 3.16 when 3.16 is released).

If testing against HHVM LST versions is desired follow this guide. https://docs.travis-ci.com/user/languages/php#HHVM-versions

Should be able to change HHVM to container based Trusty after Q1-17 https://blog.travis-ci.com/2016-11-08-trusty-container-public-beta/

also adds php 7.1

### Testing Instructions
merge by code review

### Documentation Changes Required
none
